### PR TITLE
Removing change of non-link text color appearing as a link

### DIFF
--- a/css/admin-style.css
+++ b/css/admin-style.css
@@ -327,11 +327,6 @@ div#lp-store-iframe-container > iframe {
 	color:#388DBC;
 }
 
-.wp-list-table td
-{
-	color:#388DBC;
-}
-
 #wp-leads-splash-header
 {
 	background: #f2f2f2;


### PR DESCRIPTION
The rule is affecting globally on other admin areas using same class (e.g. Plugin page) and that shouldn't be happening. It's also possible to simply limit the scope of style change to the plugin's admin pages but using link color for non-link text is simply confusing and not user friendly at all. I think this CSS rule just need to be removed all together from the plugin.
